### PR TITLE
fix: register.ts and add etherscan api key to .env

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,3 +1,4 @@
 RPC_URL=https://ethereum-holesky-rpc.publicnode.com	
+ETHERSCAN_API_KEY=<your api key>
 ECDSA_PRIVATE_KEY=0xyourPrivateKey
 BLS_PRIVATE_KEY=19909175555469042151615589784701655032557115898575178510074822318325351312944 #You can generate a bls private key through the eigenlayer CLI 

--- a/script/register.ts
+++ b/script/register.ts
@@ -26,7 +26,7 @@ if (ECDSA_PRIVATE_KEY == "" || MESSAGE_POINT_X0 == "" || MESSAGE_POINT_X1 == "" 
 
 async function main() {
     const BLS = await ethers.getContractFactory("BLS");
-    const wallet = new ethers.Wallet(BLS_CONTRACT_ADDRESS, ethers.provider);
+    const wallet = new ethers.Wallet(ECDSA_PRIVATE_KEY, ethers.provider);
     const BLSContract = new ethers.Contract("0xD29a2484C1D0EE935A1c4d197b20206dd8a8101C", BLS.interface, wallet);
 
     const msgpoint: G1PointStruct = { X: MESSAGE_POINT_X0, Y: MESSAGE_POINT_X1 };

--- a/script/register.ts
+++ b/script/register.ts
@@ -27,7 +27,7 @@ if (ECDSA_PRIVATE_KEY == "" || MESSAGE_POINT_X0 == "" || MESSAGE_POINT_X1 == "" 
 async function main() {
     const BLS = await ethers.getContractFactory("BLS");
     const wallet = new ethers.Wallet(ECDSA_PRIVATE_KEY, ethers.provider);
-    const BLSContract = new ethers.Contract("0xD29a2484C1D0EE935A1c4d197b20206dd8a8101C", BLS.interface, wallet);
+    const BLSContract = new ethers.Contract(BLS_CONTRACT_ADDRESS, BLS.interface, wallet);
 
     const msgpoint: G1PointStruct = { X: MESSAGE_POINT_X0, Y: MESSAGE_POINT_X1 };
     const apkg1: G1PointStruct = { X: G1_PUBKEY_X0, Y: G1_PUBKEY_X1 };


### PR DESCRIPTION
Some changes required to register.ts to get the onchain registration to work correctly. Also add etherscan api key to .example.env.